### PR TITLE
fix: Set the default_auto_field

### DIFF
--- a/charts/apps.py
+++ b/charts/apps.py
@@ -2,4 +2,5 @@ from django.apps import AppConfig
 
 
 class ChartsConfig(AppConfig):
+    default_auto_field = "django.db.models.AutoField"
     name = 'charts'


### PR DESCRIPTION
Django gives a warning if there is no default auto field set.
Maintaining the historical behavior, the default value for
DEFAULT_AUTO_FIELD is AutoField. We are setting this value to avoid
unwanted migrations for users.
Starting with Django 3.2 new apps are generated with
AppConfig.default_auto_field set to BigAutoField.
See https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys
